### PR TITLE
Provide fallback trim() implementation

### DIFF
--- a/autoload/agriculture.vim
+++ b/autoload/agriculture.vim
@@ -10,7 +10,7 @@ endfunction
 
 function! agriculture#trim_and_escape_register_a()
   let query = getreg('a')
-  let trimmedQuery = trim(query)
+  let trimmedQuery = s:trim(query)
   let escapedQuery = escape(trimmedQuery, "'#%\\")
   call setreg('a', escapedQuery)
 endfunction
@@ -20,7 +20,7 @@ function! agriculture#fzf_ag_raw(command_suffix, ...)
     return s:warn('ag is not found')
   endif
   let userOptions = get(g:, 'agriculture#ag_options', '')
-  let command = 'ag --nogroup --column --color ' . trim(userOptions . ' ' . a:command_suffix)
+  let command = 'ag --nogroup --column --color ' . s:trim(userOptions . ' ' . a:command_suffix)
   return call('fzf#vim#grep', extend([command, 1], a:000))
 endfunction
 
@@ -29,8 +29,16 @@ function! agriculture#fzf_rg_raw(command_suffix, ...)
     return s:warn('rg is not found')
   endif
   let userOptions = get(g:, 'agriculture#rg_options', '')
-  let command = 'rg --column --line-number --no-heading --color=always ' . trim(userOptions . ' ' . a:command_suffix)
+  let command = 'rg --column --line-number --no-heading --color=always ' . s:trim(userOptions . ' ' . a:command_suffix)
   return call('fzf#vim#grep', extend([command, 1], a:000))
+endfunction
+
+function! s:trim(str)
+  if exists('*trim')
+    return trim(a:str)
+  endif
+
+  return matchstr(a:str, '^\s*\zs.\{-}\ze\s*$')
 endfunction
 
 function! s:warn(message)


### PR DESCRIPTION
This addresses https://github.com/jesseleite/vim-agriculture/issues/4

`trim()` is available in vim version `8.0.1630` and above, and currently there is no implementation of the function in Neovim.  This PR simply adds [the current implementation of trim() in Vim](https://github.com/vim/vim/blob/b46fecd3454399f8ebdc5055302e4bfc5a10f98b/src/testdir/test_matchadd_conceal_utf8.vim#L18-L20) in case it is unavailable.

Test output:
```
Starting Vader: 2 suite(s), 8 case(s)
  Starting Vader: /Users/rperrynguyen/code/vim-agriculture/test/smart_quote_input.vader
    (1/5) [EXECUTE] Smart quotes without detected options or path
    (2/5) [EXECUTE] Hands off with quotes
    (3/5) [EXECUTE] Hands off with options
    (4/5) [EXECUTE] Hands off with space escaped query and path
    (5/5) [EXECUTE] Hands off if explicitly disabled
  Success/Total: 5/5
  Starting Vader: /Users/rperrynguyen/code/vim-agriculture/test/trim_and_escape_register_a.vader
    (1/3) [  GIVEN] A fancy star wars line that needs escaping
    (1/3) [     DO] Yank text to register a
    (2/3) [  GIVEN] A fancy star wars line that needs escaping
    (2/3) [EXECUTE] Escape text in register a
    (3/3) [  GIVEN] A fancy star wars line that needs escaping
    (3/3) [     DO] Paste escaped text from register a
    (3/3) [ EXPECT] Pasted text was properly escaped
  Success/Total: 3/3
Success/Total: 8/8 (assertions: 12/12)
Elapsed time: 0.068142 sec.
```

Tested on Neovim `0.3.8`.  Also works as expected in practical use for me.