### PR TITLE
fix(bug): error occurs when user use g:fzf_preview_window in .vimrc

### DIFF
--- a/autoload/agriculture.vim
+++ b/autoload/agriculture.vim
@@ -37,10 +37,14 @@ endfunction
 
 function! s:preview(bang, ...)
   let preview_window = get(g:, 'fzf_preview_window', a:bang && &columns >= 80 || &columns >= 120 ? 'right': '')
-  if len(preview_window)
-    return call('fzf#vim#with_preview', add(copy(a:000), preview_window))
+  if empty(preview_window)
+    return {}
   endif
-  return {}
+  " For backward-compatiblity
+  if type(preview_window) == type('')
+    let preview_args = [preview_window]
+  endif
+  return call('fzf#vim#with_preview', extend(copy(a:000), preview_window))
 endfunction
 
 function! s:trim(str)


### PR DESCRIPTION
I find a bug when I'm using this plugin.

If I use the global variable fzf_preview_window like [this](https://github.com/junegunn/fzf.vim#preview-window):
```
let g:fzf_preview_window = ['right:50%', 'ctrl-/']
```
There would be an error like this when I want to search something.
<img width="998" alt="image" src="https://user-images.githubusercontent.com/13324537/100567948-b7b65e00-3304-11eb-86c8-90c28b74de06.png">
So I go to the [fzf.vim](https://github.com/junegunn/fzf.vim/blob/master/plugin/fzf.vim#L42) to find the source code and modify the code in agriculture and it works.
