### PR TITLE
Fix bug with leader shortcuts for search

### DIFF
--- a/plugin/agriculture.vim
+++ b/plugin/agriculture.vim
@@ -7,9 +7,9 @@ nnoremap <Plug>AgRawSearch :AgRaw<Space>
 nnoremap <Plug>RgRawSearch :RgRaw<Space>
 
 " Mappings to search visual selection
-vnoremap <Plug>AgRawVisualSelection "ay:call agriculture#trim_and_escape_register_a()<CR>:AgRaw -Q -- $'<C-r>a'
-vnoremap <Plug>RgRawVisualSelection "ay:call agriculture#trim_and_escape_register_a()<CR>:RgRaw -F -- $'<C-r>a'
+vnoremap <Plug>AgRawVisualSelection "ay:call agriculture#trim_and_escape_register_a()<CR>:AgRaw -Q -- '<C-r>a'
+vnoremap <Plug>RgRawVisualSelection "ay:call agriculture#trim_and_escape_register_a()<CR>:RgRaw -F -- '<C-r>a'
 
 " Mappings to search word under cursor
-nnoremap <Plug>AgRawWordUnderCursor "ayiw:call agriculture#trim_and_escape_register_a()<CR>:AgRaw -Q -- $'<C-r>a'
-nnoremap <Plug>RgRawWordUnderCursor "ayiw:call agriculture#trim_and_escape_register_a()<CR>:RgRaw -F -- $'<C-r>a'
+nnoremap <Plug>AgRawWordUnderCursor "ayiw:call agriculture#trim_and_escape_register_a()<CR>:AgRaw -Q -- '<C-r>a'
+nnoremap <Plug>RgRawWordUnderCursor "ayiw:call agriculture#trim_and_escape_register_a()<CR>:RgRaw -F -- '<C-r>a'


### PR DESCRIPTION
The $ character in the <leader> shortcuts would mean that the search always returned empty. If we remove the $, the searches work as expected.

Closes #13.