### PR TITLE
Switch escape to shellescape

### DIFF
--- a/autoload/agriculture.vim
+++ b/autoload/agriculture.vim
@@ -11,7 +11,7 @@ endfunction
 function! agriculture#trim_and_escape_register_a()
   let query = getreg('a')
   let trimmedQuery = s:trim(query)
-  let escapedQuery = escape(trimmedQuery, "'#%\\")
+  let escapedQuery = shellescape(trimmedQuery)
   call setreg('a', escapedQuery)
 endfunction
 

--- a/plugin/agriculture.vim
+++ b/plugin/agriculture.vim
@@ -7,9 +7,9 @@ nnoremap <Plug>AgRawSearch :AgRaw<Space>
 nnoremap <Plug>RgRawSearch :RgRaw<Space>
 
 " Mappings to search visual selection
-vnoremap <Plug>AgRawVisualSelection "ay:call agriculture#trim_and_escape_register_a()<CR>:AgRaw -Q -- $'<C-r>a'
-vnoremap <Plug>RgRawVisualSelection "ay:call agriculture#trim_and_escape_register_a()<CR>:RgRaw -F -- $'<C-r>a'
+vnoremap <Plug>AgRawVisualSelection "ay:call agriculture#trim_and_escape_register_a()<CR>:AgRaw -Q -- <C-r>a
+vnoremap <Plug>RgRawVisualSelection "ay:call agriculture#trim_and_escape_register_a()<CR>:RgRaw -F -- <C-r>a
 
 " Mappings to search word under cursor
-nnoremap <Plug>AgRawWordUnderCursor "ayiw:call agriculture#trim_and_escape_register_a()<CR>:AgRaw -Q -- $'<C-r>a'
-nnoremap <Plug>RgRawWordUnderCursor "ayiw:call agriculture#trim_and_escape_register_a()<CR>:RgRaw -F -- $'<C-r>a'
+nnoremap <Plug>AgRawWordUnderCursor "ayiw:call agriculture#trim_and_escape_register_a()<CR>:AgRaw -Q -- <C-r>a
+nnoremap <Plug>RgRawWordUnderCursor "ayiw:call agriculture#trim_and_escape_register_a()<CR>:RgRaw -F -- <C-r>a


### PR DESCRIPTION
Fixes #13 

Vim's [shellescape](https://github.com/vim/vim/blob/160a2b4dac198f31fbcff9d696548e011c4602c1/runtime/doc/eval.txt#L9838-L9839) will escape the copied string for use in shell commands.
This includes enclosing the string in quotes:

> will enclose {string} in single quotes and replace all "'" with "'\''".

This removes the need for bash [ANSI-C quotes][2], which is not available in all shells, namely fish.

[2]: https://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html

### Testing
I applied these changes directly to nvim bundle to test. Tested in bash and fish. Then tested on this file, which contains dollar sign, single quote, hex, and alert.

```
echo $'"hello" \a\x77orld'
```

This is an example of what I get when visually selecting entire line
```
:RgRaw -F -- 'echo $'\''"hello" \a\x77orld'\'''
```