### PR TITLE
Properly convert preview_window to a list

### DIFF
--- a/autoload/agriculture.vim
+++ b/autoload/agriculture.vim
@@ -42,7 +42,7 @@ function! s:preview(bang, ...)
   endif
   " For backward-compatiblity
   if type(preview_window) == type('')
-    let preview_args = [preview_window]
+    let preview_window = [preview_window]
   endif
   return call('fzf#vim#with_preview', extend(copy(a:000), preview_window))
 endfunction


### PR DESCRIPTION
If `preview_window` is a string, it was not converted to a list and gave me an error.
```
E712: Argument of extend() must be a List or Dictionary
```